### PR TITLE
Add explicit raven exception capture to transition hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,11 +108,15 @@ DecafAppModule.config((appNameProvider, appAuthProvider, potionProvider, decafAP
     });
     // Track page state changes to Google Analytics
     $transitions.onSuccess({}, (transition) => {
-        gtag('config', process.env.GA_TRACKING_CODE, {
-            page_title: (transition.to().data && transition.to().data.title) || appName,
-            page_location: $location.absUrl(),
-            page_path: $location.path(),
-        });
+        try {
+            gtag('config', process.env.GA_TRACKING_CODE, {
+                page_title: (transition.to().data && transition.to().data.title) || appName,
+                page_location: $location.absUrl(),
+                page_path: $location.path(),
+            });
+        } catch(ex) {
+            Raven.captureException(ex);
+        }
     });
 });
 


### PR DESCRIPTION
Exceptions during transition hooks in ui-router [are caught](https://github.com/ui-router/core/blob/3.1.0/src/transition/transitionHook.ts#L92) (the applicable handler being `LOG_ERROR`), which must be why exceptions in this code block are not sent to Sentry.

Cannot see any way to configure the error handlers (may have missed something) so the simplest solution seems to be to just wrap the hook manually.

Fixes the sentry issue from #21 